### PR TITLE
Update mk2parts.sh for non-english linux

### DIFF
--- a/scripts/mk2parts.sh
+++ b/scripts/mk2parts.sh
@@ -32,7 +32,7 @@ else
 fi
 
 
-SIZE=`fdisk -l $DRIVE | grep "Disk $DRIVE" | cut -d' ' -f5`
+SIZE=`fdisk -l $DRIVE | grep "$DRIVE" | cut -d' ' -f5 | grep -o -E '[0-9]+`
 
 echo DISK SIZE – $SIZE bytes
 


### PR DESCRIPTION
Here is a little update of the SIZE variable to take care of other language. The command 'grep "Disk $DRIVE"' is not working on non-english version.