### PR TITLE
u-boot: Only set filenames for "beaglebone" machine

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,2 +1,2 @@
-UBOOT_SUFFIX = "img"
-SPL_BINARY = "MLO"
+UBOOT_SUFFIX:beaglebone = "img"
+SPL_BINARY:beaglebone = "MLO"


### PR DESCRIPTION
## Description

This PR tags the u-boot filename parts as beaglebone-only.

## Motivation and Context

My company is looking to support both BeagleBone and RPi 4/5 for our next-gen platform (currently we're just on the BeagleBone). We use Mender and thus need u-boot support for the RPi. The filename definitions needed for beaglebone break RPi, so we should scope them to just the `beaglebone` machine.

## How has this been tested?

Before, building RPi 4:

```
ERROR: u-boot-1_2024.04-r0 do_deploy: ExecutionError('tmp-sundstrom-glibc/work/raspberrypi4_64-sundstrom-linux/u-boot/2024.04/temp/run.do_deploy.929641', 1, None, None)
ERROR: Logfile of failure stored in: tmp-sundstrom-glibc/work/raspberrypi4_64-sundstrom-linux/u-boot/2024.04/temp/log.do_deploy.929641
Log data follows:
| DEBUG: Executing python function sstate_task_prefunc
| DEBUG: Python function sstate_task_prefunc finished
| DEBUG: Executing shell function do_deploy
| install: cannot stat 'tmp-sundstrom-glibc/work/raspberrypi4_64-sundstrom-linux/u-boot/2024.04/build/u-boot.img': No such file or directory
| WARNING: exit code 1 from a shell command.
ERROR: Task (conf/../layers/meta-lts-mixins/recipes-bsp/u-boot/u-boot_2024.04.bb:do_deploy) failed with exit code '1'
ERROR: u-boot-1_2024.04-r0 do_install: ExecutionError('tmp-sundstrom-glibc/work/raspberrypi4_64-sundstrom-linux/u-boot/2024.04/temp/run.do_install.929642', 1, None, None)
```

After: Build succeeds for both BeagleBone and RPi 4/5.

Runtime tested on beaglebone, rpi 4 and rpi 5. No errors observed.